### PR TITLE
chore(plugin): Rename trivy-aws plugin

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -8,8 +8,8 @@ plugins:
       maintainer: aquasecurity
       summary: Send results to Aqua Security
       output: false
-    - name: aws-scan
-      version: 0.11.0
+    - name: aws
+      version: 0.12.0
       repository: github.com/aquasecurity/trivy-aws
       maintainer: aquasecurity
       summary: Trivy AWS Cloud scanning plugin

--- a/plugins/aws-scan.yaml
+++ b/plugins/aws-scan.yaml
@@ -1,2 +1,2 @@
-name: aws-scan
+name: aws
 repository: github.com/aquasecurity/trivy-aws


### PR DESCRIPTION
Needs https://github.com/aquasecurity/trivy-aws/pull/181 to be merged and the new release for the plugin.