### PR TITLE
Add `vexllm` plugin (silence negligible CVE using LLM)

### DIFF
--- a/plugins/vexllm.yaml
+++ b/plugins/vexllm.yaml
@@ -1,0 +1,2 @@
+name: vexllm
+repository: github.com/AkihiroSuda/vexllm


### PR DESCRIPTION
https://github.com/AkihiroSuda/vexllm

VexLLM silences negligible CVE alerts using LLM.

Usage:
```
  # Set OpenAI API key
  export OPENAI_API_KEY=...

  # Specify OpenAI model
  export OPENAI_MODEL=gpt-4o-mini

  # Generate a report using Trivy
  trivy image python:3.12.4 --format=json --severity HIGH,CRITICAL >python.json

  # Generate .trivyignore using VexLLM
  trivy vexllm generate python.json .trivyignore \
    --hint-not-server \
    --hint-compromise-on-availability \
    --hint-used-commands=python3 \
    --hint-unused-commands=git,wget,curl,apt,apt-get

  # Print the report, using the generated .trivyignore
  trivy convert --format=table python.json
```